### PR TITLE
fix: export a few utilities needed for extending

### DIFF
--- a/src/anoncreds/index.ts
+++ b/src/anoncreds/index.ts
@@ -1,5 +1,5 @@
 export {
-	CacheSettings,
-	DidWebAnonCredsRegistry,
-} from "./DidWebAnonCredsRegistry";
-export { calculateResourceId } from "./utils";
+  CacheSettings,
+  DidWebAnonCredsRegistry,
+} from './DidWebAnonCredsRegistry'
+export { calculateResourceId } from './utils'

--- a/src/anoncreds/index.ts
+++ b/src/anoncreds/index.ts
@@ -1,1 +1,5 @@
-export { DidWebAnonCredsRegistry } from './DidWebAnonCredsRegistry'
+export {
+	CacheSettings,
+	DidWebAnonCredsRegistry,
+} from "./DidWebAnonCredsRegistry";
+export { calculateResourceId } from "./utils";


### PR DESCRIPTION
Paradym extends `DidWebAnonCredsRegistry`, for which we need a few more utilities and types to be exported.

We were doing some dirty imports from the `./build` directory, which is no longer possible.