### PR TITLE
fix: cache settings export

### DIFF
--- a/src/anoncreds/index.ts
+++ b/src/anoncreds/index.ts
@@ -1,5 +1,5 @@
 export {
-  CacheSettings,
+  type CacheSettings,
   DidWebAnonCredsRegistry,
 } from './DidWebAnonCredsRegistry'
 export { calculateResourceId } from './utils'


### PR DESCRIPTION
We need to actually just export as `type` to make it work...