### PR TITLE
fix: add default export condition for CJS compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,8 +32,9 @@
     "types": "./build/index.d.mts",
     "exports": {
       ".": {
+        "types": "./build/index.d.mts",
         "import": "./build/index.mjs",
-        "types": "./build/index.d.mts"
+        "default": "./build/index.mjs"
       },
       "./package.json": "./package.json"
     }


### PR DESCRIPTION
### Problem
The exports field only had an `import` condition, causing ERR_PACKAGE_PATH_NOT_EXPORTED when loaded via Node.js CJS require().

### Fix:
Added a `default` fallback pointing to the same ./build/index.mjs.